### PR TITLE
Additional Project properties

### DIFF
--- a/plugins/modules/gns3_project.py
+++ b/plugins/modules/gns3_project.py
@@ -53,7 +53,7 @@ options:
         type: str
     project_path:
         description:
-            - Project path (Ignore in name not specified)
+            -  Path of the project on the server ( Optional, Ignored if project_name not specified )
         type: str
     scene_height:
         description:

--- a/plugins/modules/gns3_project.py
+++ b/plugins/modules/gns3_project.py
@@ -55,6 +55,14 @@ options:
         description:
             - Project path (Ignore in name not specified)
         type: str
+    scene_height:
+        description:
+            - Scene height
+        type: str
+    scene_width:
+        description:
+            - Scene width
+        type: str
     project_id:
         description:
             - Project ID
@@ -288,6 +296,8 @@ def main():
             ),
             project_name=dict(type="str", default=None),
             project_path=dict(type="str", default=None),
+            scene_height=dict(type="str", default=None),
+            scene_width=dict(type="str", default=None),
             project_id=dict(type="str", default=None),
             nodes_state=dict(type="str", choices=["started", "stopped"]),
             nodes_strategy=dict(
@@ -315,6 +325,8 @@ def main():
     state = module.params["state"]
     project_name = module.params["project_name"]
     project_path = module.params["project_path"]
+    scene_height = module.params["scene_height"]
+    scene_width = module.params["scene_width"]
     project_id = module.params["project_id"]
     nodes_state = module.params["nodes_state"]
     nodes_strategy = module.params["nodes_strategy"]
@@ -330,9 +342,9 @@ def main():
         )
         # Define the project
         if project_name is not None:
-            project = Project(name=project_name, path=project_path, connector=server)
+            project = Project(name=project_name, path=project_path, scene_height=scene_height, scene_width=scene_width, connector=server)
         elif project_id is not None:
-            project = Project(project_id=project_id, connector=server)
+            project = Project(project_id=project_id, scene_height=scene_height, scene_width=scene_width, connector=server)
     except Exception as err:
         module.fail_json(msg=str(err), **result)
 

--- a/plugins/modules/gns3_project.py
+++ b/plugins/modules/gns3_project.py
@@ -51,6 +51,10 @@ options:
         description:
             - Project name
         type: str
+    project_path:
+        description:
+            - Project path (Ignore in name not specified)
+        type: str
     project_id:
         description:
             - Project ID
@@ -283,6 +287,7 @@ def main():
                 choices=["opened", "closed", "present", "absent"],
             ),
             project_name=dict(type="str", default=None),
+            project_path=dict(type="str", default=None),
             project_id=dict(type="str", default=None),
             nodes_state=dict(type="str", choices=["started", "stopped"]),
             nodes_strategy=dict(
@@ -309,6 +314,7 @@ def main():
     server_password = module.params["password"]
     state = module.params["state"]
     project_name = module.params["project_name"]
+    project_path = module.params["project_path"]
     project_id = module.params["project_id"]
     nodes_state = module.params["nodes_state"]
     nodes_strategy = module.params["nodes_strategy"]
@@ -324,7 +330,7 @@ def main():
         )
         # Define the project
         if project_name is not None:
-            project = Project(name=project_name, connector=server)
+            project = Project(name=project_name, path=project_path, connector=server)
         elif project_id is not None:
             project = Project(project_id=project_id, connector=server)
     except Exception as err:
@@ -346,7 +352,6 @@ def main():
 
                 # Now verify nodes
                 if nodes_state is not None:
-
                     # Change flag based on the nodes state
                     result["changed"] = nodes_state_verification(
                         expected_nodes_state=nodes_state,


### PR DESCRIPTION
Additional project properties for scene_height, scene_width and project_path.
project_path is only used if Project name is also specified as it make no sense to put a friendly path on a project identified by a GUID
if no value for scene_height and scene_width is specified they are set null so the GNS3 defaults are respected